### PR TITLE
brotli 0.0.0.1: use internalError instead of MonadFail ST (GHC 9.4)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,22 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20220525
 #
-# REGENDATA ("0.14.3",["github","brotli.cabal"])
+# REGENDATA ("0.15.20220525",["github","brotli.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.0.20220501
+            compilerKind: ghc
+            compilerVersion: 9.4.0.20220501
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.2.2
             compilerKind: ghc
             compilerVersion: 9.2.2
@@ -96,8 +105,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            if $HEADHACKAGE; then "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml; fi
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
             apt-get update
@@ -107,7 +117,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME" libbrotli-dev
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -140,7 +150,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -169,6 +179,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -220,6 +241,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(brotli)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -252,7 +276,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+
+0.0.0.1
+-------
+
+_Andreas Abel, 2022-06-10_
+
+- Support `base-4.17` which dropped `instance MonadFail ST`.
+- Tested with GHC 7.4 - 9.4.
+
+
+0.0.0.0
+-------
+
+_Herbert Valerio Riedel, 2019-04-20_
+
+Let there be light!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# brotli Haskell library
+
+[Brotli](http://brotli.org)
+([RFC7932](https://tools.ietf.org/html/rfc7932))
+is a generic-purpose lossless compression algorithm suitable for
+[HTTP compression](https://en.wikipedia.org/wiki/HTTP_compression)
+that compresses data using a combination of a modern variant of the
+LZ77 algorithm, Huffman coding and 2nd order context modeling.
+
+This package provides a pure interface for compressing and
+decompressing Brotli streams of data represented as lazy
+`ByteString`s. A monadic incremental interface is provided as well.
+This package relies on Google's C implementation.
+
+The following packages are based on this package and provide
+API support for popular streaming frameworks:
+
+  * [brotli-streams](https://hackage.haskell.org/package/brotli-streams)
+    for [io-streams](https://hackage.haskell.org/package/io-streams)
+
+  * [pipes-brotli](https://hackage.haskell.org/package/pipes-brotli)
+    for [pipes](https://hackage.haskell.org/package/pipes)
+
+  * [brotli-conduit](https://hackage.haskell.org/package/brotli-conduit)
+    for [conduit](https://hackage.haskell.org/package/conduit)

--- a/brotli.cabal
+++ b/brotli.cabal
@@ -9,7 +9,7 @@ bug-reports:         https://github.com/haskell-hvr/brotli/issues
 license:             GPL-3
 license-file:        LICENSE
 author:              Herbert Valerio Riedel
-maintainer:          hvr@gnu.org
+maintainer:          https://github.com/haskell-hvr/brotli
 copyright:           (c) 2016, Herbert Valerio Riedel
 category:            Codec, Compression
 description:
@@ -47,6 +47,7 @@ tested-with:
 
 
 extra-source-files:
+  CHANGELOG.md
   cbits/hs_brotli.h
 
 source-repository head

--- a/brotli.cabal
+++ b/brotli.cabal
@@ -1,12 +1,11 @@
 cabal-version:       1.12
 build-type:          Simple
 name:                brotli
-version:             0.0.0.0
-x-revision:          4
+version:             0.0.0.1
 
 synopsis:            Brotli (RFC7932) compression and decompression
-homepage:            https://github.com/hvr/brotli
-bug-reports:         https://github.com/hvr/brotli/issues
+homepage:            https://github.com/haskell-hvr/brotli
+bug-reports:         https://github.com/haskell-hvr/brotli/issues
 license:             GPL-3
 license-file:        LICENSE
 author:              Herbert Valerio Riedel
@@ -32,6 +31,7 @@ description:
     .
 
 tested-with:
+  GHC == 9.4.1
   GHC == 9.2.2
   GHC == 9.0.2
   GHC == 8.10.7
@@ -51,16 +51,16 @@ extra-source-files:
 
 source-repository head
   type:     git
-  location: https://github.com/hvr/brotli.git
+  location: https://github.com/haskell-hvr/brotli.git
 
 library
   hs-source-dirs:      src
   exposed-modules:     Codec.Compression.Brotli
   other-modules:       LibBrotli
 
-  build-depends:       base         >=4.5     && <4.17
+  build-depends:       base         >=4.5     && <4.18
                      , bytestring   >=0.9.2   && <0.12
-                     , transformers >=0.3.0.0 && <0.6
+                     , transformers >=0.3.0.0 && <0.7
 
   default-language:    Haskell2010
 
@@ -70,6 +70,8 @@ library
   include-dirs:        cbits
 
   ghc-options:         -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wcompat
 
 test-suite brotli-tests
   default-language:    Haskell2010
@@ -90,3 +92,5 @@ test-suite brotli-tests
                      , tasty-quickcheck            == 0.10.*
 
   ghc-options:         -Wall -threaded
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wcompat

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,2 @@
 apt: libbrotli-dev
+branches: master

--- a/cbits/hs_brotli.h
+++ b/cbits/hs_brotli.h
@@ -51,7 +51,7 @@ HsBrotliEncoderCompressStream (BrotliEncoderState* state,
       }
   }
 
-  return HS_BS_INTERNAL_ERROR;  
+  return HS_BS_INTERNAL_ERROR;
 }
 
 static inline HsBrotliState
@@ -87,7 +87,7 @@ HsBrotliEncoderTakeOutput (BrotliEncoderState* state, size_t* sizep, uint8_t** b
   *buf_out = (uint8_t*) BrotliEncoderTakeOutput(state, sizep);
 
   const size_t size = *sizep;
-  
+
   if (!*buf_out && size != 0) {
     *sizep = 0;
     return HS_BS_INTERNAL_ERROR;
@@ -100,7 +100,7 @@ HsBrotliEncoderTakeOutput (BrotliEncoderState* state, size_t* sizep, uint8_t** b
     case BROTLI_TRUE: return HS_BS_FINISHED;
     case BROTLI_FALSE: return HS_BS_NEEDS_INPUT;
     }
-    return HS_BS_INTERNAL_ERROR;  
+    return HS_BS_INTERNAL_ERROR;
   }
 
   // non-empty
@@ -115,7 +115,7 @@ HsBrotliEncoderTakeOutput (BrotliEncoderState* state, size_t* sizep, uint8_t** b
 
   *sizep = 0;
   *buf_out = NULL;
-  return HS_BS_INTERNAL_ERROR;  
+  return HS_BS_INTERNAL_ERROR;
 }
 
 static inline HsBrotliState
@@ -124,7 +124,7 @@ HsBrotliDecoderTakeOutput (BrotliDecoderState* state, size_t* sizep, uint8_t** b
   *buf_out = (uint8_t*) BrotliDecoderTakeOutput(state, sizep);
 
   const size_t size = *sizep;
-  
+
   if (!*buf_out && size != 0) {
     *sizep = 0;
     return HS_BS_INTERNAL_ERROR;
@@ -137,7 +137,7 @@ HsBrotliDecoderTakeOutput (BrotliDecoderState* state, size_t* sizep, uint8_t** b
     case BROTLI_TRUE: return HS_BS_FINISHED;
     case BROTLI_FALSE: return HS_BS_NEEDS_INPUT;
     }
-    return HS_BS_INTERNAL_ERROR;  
+    return HS_BS_INTERNAL_ERROR;
   }
 
   // non-empty
@@ -152,7 +152,7 @@ HsBrotliDecoderTakeOutput (BrotliDecoderState* state, size_t* sizep, uint8_t** b
 
   *sizep = 0;
   *buf_out = NULL;
-  return HS_BS_INTERNAL_ERROR;  
+  return HS_BS_INTERNAL_ERROR;
 }
 
 static inline char*

--- a/src-tests/brotli-tests.hs
+++ b/src-tests/brotli-tests.hs
@@ -3,17 +3,17 @@
 module Main (main) where
 
 import           Control.Applicative
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
-import           Data.ByteString.Lazy.Char8 ()
-import           Data.List
+import qualified Data.ByteString             as BS
+import qualified Data.ByteString.Lazy        as BL
+import           Data.ByteString.Lazy.Char8  ()
+import           Data.List                   (intersperse)
 import           Prelude
 
 import           Test.Tasty
-import           Test.Tasty.QuickCheck as QC
+import           Test.Tasty.QuickCheck       as QC
 import           Test.Tasty.HUnit
 
-import           Codec.Compression.Brotli as Brotli
+import           Codec.Compression.Brotli    as Brotli
 
 main :: IO ()
 main = defaultMain tests


### PR DESCRIPTION
- fixes #5
- bump `base` and `transformers`
- include GHC 9.4 in Haskell CI
- add `-Wcompat`